### PR TITLE
hit connexion callbacks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,10 +77,18 @@ impl KVMi {
     }
 
     fn close(&mut self) {
-        unsafe {
-            kvmi_sys::kvmi_uninit(self.ctx);
-        };
-        self.ctx = null_mut();
+        if self.ctx != null_mut() {
+            unsafe {
+                kvmi_sys::kvmi_uninit(self.ctx);
+            };
+            self.ctx = null_mut();
+        }
+        if self.dom != null_mut() {
+            unsafe {
+                kvmi_sys::kvmi_domain_close(self.dom, true);
+            };
+            self.dom = null_mut();
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ impl KVMi {
             guard: Mutex::new(false),
             condvar: Condvar::new(),
         };
-        let cb_ctx: *mut c_void = &mut kvmi_con as *mut _ as *mut c_void;
+        let cb_ctx: *mut c_void = &mut kvmi_con as *mut _ as *mut _;
         // kvmi_dom = NULL
         let lock = kvmi_con.guard.lock().unwrap();
         kvmi.ctx = unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,11 +43,11 @@ impl KVMi {
     pub fn new(socket_path: String) -> KVMi {
         let socket_path = CString::new(socket_path.into_bytes()).unwrap();
         let accept_db = Some(new_guest_cb as
-                             unsafe extern fn(*mut c_void,
+                             unsafe extern "C" fn(*mut c_void,
                                               *mut [c_uchar; 16usize],
                                               *mut c_void) -> c_int);
         let hsk_cb = Some(handshake_cb as
-                          unsafe extern fn(*const kvmi_qemu2introspector,
+                          unsafe extern "C" fn(*const kvmi_qemu2introspector,
                                            *mut kvmi_introspector2qemu,
                                            *mut c_void) -> c_int);
         let mut kvmi = KVMi {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ struct KVMiCon {
     condvar: Condvar,
 }
 
-extern "C" fn new_guest_cb(dom: *mut c_void,
+unsafe extern "C" fn new_guest_cb(dom: *mut c_void,
                            uuid: *mut [c_uchar; 16usize],
                            cb_ctx: *mut c_void) -> c_int {
     println!("new guest cb !");
@@ -65,7 +65,7 @@ impl KVMi {
         kvmi.ctx = unsafe {
             kvmi_sys::kvmi_init_unix_socket(socket_path.as_ptr(), accept_db, hsk_cb, cb_ctx)
         };
-        if kvmi.ctx != null_mut() {
+        if !kvmi.ctx.is_null() {
             // wait for connexion
             println!("Waiting for connexion..");
             kvmi_con.condvar.wait(lock).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,9 @@ unsafe extern "C" fn new_guest_cb(dom: *mut c_void,
                            uuid: *mut [c_uchar; 16usize],
                            cb_ctx: *mut c_void) -> c_int {
     println!("new guest cb !");
+    if cb_ctx.is_null() {
+        panic!("Unexpected null context");
+    }
     let kvmi_con = unsafe { &mut *(cb_ctx as *mut KVMiCon) };
     let mut started = kvmi_con.guard.lock().unwrap();
     kvmi_con.dom = dom;


### PR DESCRIPTION
This PR is a WIP to implement the following connexion logic in Rust:
https://github.com/KVM-VMI/libvmi/blob/kvmi/libvmi/driver/kvm/kvm.c#L189

![Screenshot_20190710_221417](https://user-images.githubusercontent.com/964610/61001741-7a90ab00-a360-11e9-952f-869b007e12a5.png)

It's not pretty, and lacks error handling, but it works for testing the API now.

cc @tathanhdinh