### PR TITLE
update new CR value in event reply

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,7 @@ impl KVMi {
             }
             KVMiEventType::Cr {
                 cr_type: _,
-                new: _,
+                new,
                 old: _,
             } => {
                 #[repr(C)]
@@ -303,6 +303,7 @@ impl KVMi {
                 reply.common = reply_common;
                 // set event specific attributes
                 // reply.cr.xxx = ...
+                reply.cr.new_val = new;
                 let size = mem::size_of::<EventReplyCr>();
                 let rpl_ptr: *const c_void = &reply as *const _ as *const c_void;
                 unsafe { kvmi_sys::kvmi_reply_event(self.dom, seq, rpl_ptr, size as usize) }


### PR DESCRIPTION
CR events support: this PR updates the new value assigned to the Control Register, in the event reply.

If we don't do this, the guest crashes.
