### PR TITLE
cargo: fill required keys for publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,13 @@ name = "kvmi"
 version = "0.1.0"
 authors = ["Mathieu Tarral <mathieu.tarral@protonmail.com>"]
 edition = "2018"
-repository = "https://github.com/Wenzel/kvmi"
+description = "Safe bindings for libkvmi"
 readme = "README.md"
-keywords = ["KVM", "KVMi"]
-description = "Rust bindings for KVMi"
+homepage = "https://github.com/Wenzel/kvmi"
+repository = "https://github.com/Wenzel/kvmi"
 license = "GPL-3.0-only"
+keywords = ["KVM", "KVMi", "introspection", "VMI"]
+categories = ["api-bindings"]
 
 
 [dependencies]


### PR DESCRIPTION
help fix https://github.com/Wenzel/libmicrovmi/issues/108