### PR TITLE
Update to kvmi-v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           repository: bitdefender/libkvmi
           path: libkvmi
-          ref: kvmi-v6
+          ref: bf5776319e1801b59125c994c459446f0ed6837e
 
       - name: build and install libkvmi
         run: |
@@ -87,7 +87,7 @@ jobs:
         with:
           repository: bitdefender/libkvmi
           path: libkvmi
-          ref: kvmi-v6
+          ref: bf5776319e1801b59125c994c459446f0ed6837e
 
       - name: build and install libkvmi
         run: |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,7 +232,7 @@ pub trait KVMIntrospectable: std::fmt::Debug {
     fn control_msr(&self, vcpu: u16, reg: u32, enabled: bool) -> Result<(), Error>;
     fn read_physical(&self, gpa: u64, buffer: &mut [u8]) -> Result<(), Error>;
     fn write_physical(&self, gpa: u64, buffer: &[u8]) -> Result<(), Error>;
-    fn set_page_access(&self, gpa: u64, access: KVMiPageAccess) -> Result<(), Error>;
+    fn set_page_access(&self, gpa: u64, access: KVMiPageAccess, view: u16) -> Result<(), Error>;
     fn pause(&self) -> Result<(), Error>;
     fn get_vcpu_count(&self) -> Result<u32, Error>;
     fn get_registers(&self, vcpu: u16) -> Result<(kvm_regs, kvm_sregs, KvmMsrs), Error>;
@@ -362,9 +362,15 @@ impl KVMIntrospectable for KVMi {
         Ok(())
     }
 
-    fn set_page_access(&self, mut gpa: u64, access: KVMiPageAccess) -> Result<(), Error> {
+    fn set_page_access(
+        &self,
+        mut gpa: u64,
+        access: KVMiPageAccess,
+        view: u16,
+    ) -> Result<(), Error> {
         let count: c_ushort = 1;
-        let res = (self.libkvmi.set_page_access)(self.dom, &mut gpa, &mut (access as u8), count);
+        let res =
+            (self.libkvmi.set_page_access)(self.dom, &mut gpa, &mut (access as u8), count, view);
         if res != 0 {
             return Err(Error::last_os_error());
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,7 +232,6 @@ pub trait KVMIntrospectable: std::fmt::Debug {
     fn control_msr(&self, vcpu: u16, reg: u32, enabled: bool) -> Result<(), Error>;
     fn read_physical(&self, gpa: u64, buffer: &mut [u8]) -> Result<(), Error>;
     fn write_physical(&self, gpa: u64, buffer: &[u8]) -> Result<(), Error>;
-    fn get_page_access(&self, gpa: u64) -> Result<KVMiPageAccess, Error>;
     fn set_page_access(&self, gpa: u64, access: KVMiPageAccess) -> Result<(), Error>;
     fn pause(&self) -> Result<(), Error>;
     fn get_vcpu_count(&self) -> Result<u32, Error>;
@@ -361,15 +360,6 @@ impl KVMIntrospectable for KVMi {
             return Err(Error::last_os_error());
         }
         Ok(())
-    }
-
-    fn get_page_access(&self, gpa: u64) -> Result<KVMiPageAccess, Error> {
-        let mut access: c_uchar = 0;
-        let res = (self.libkvmi.get_page_access)(self.dom, gpa, &mut access);
-        if res != 0 {
-            return Err(Error::last_os_error());
-        }
-        Ok(access.try_into().unwrap())
     }
 
     fn set_page_access(&self, mut gpa: u64, access: KVMiPageAccess) -> Result<(), Error> {

--- a/src/libkvmi.rs
+++ b/src/libkvmi.rs
@@ -62,6 +62,7 @@ type FnSetPageAccess = extern "C" fn(
     gpa: *mut c_ulonglong,
     access: *mut c_uchar,
     count: c_ushort,
+    view: c_ushort,
 ) -> c_int;
 
 // kvmi_get_registers

--- a/src/libkvmi.rs
+++ b/src/libkvmi.rs
@@ -56,9 +56,6 @@ type FnReadPhysical =
 // kvmi_write_physical
 type FnWritePhysical =
     extern "C" fn(dom: *mut c_void, gpa: c_ulonglong, buffer: *const c_void, size: usize) -> c_int;
-//kvmi_get_page_access
-type FnGetPageAccess =
-    extern "C" fn(dom: *mut c_void, gpa: c_ulonglong, access: *mut c_uchar) -> c_int;
 //kvmi_set_page_access
 type FnSetPageAccess = extern "C" fn(
     dom: *mut c_void,
@@ -116,7 +113,6 @@ pub struct Libkvmi {
     pub get_vcpu_count: RawSymbol<FnGetVCPUCount>,
     pub read_physical: RawSymbol<FnReadPhysical>,
     pub write_physical: RawSymbol<FnWritePhysical>,
-    pub get_page_access: RawSymbol<FnGetPageAccess>,
     pub set_page_access: RawSymbol<FnSetPageAccess>,
     pub get_registers: RawSymbol<FnGetRegisters>,
     pub set_registers: RawSymbol<FnSetRegisters>,
@@ -185,10 +181,6 @@ impl Libkvmi {
             lib.get(b"kvmi_write_physical\0").unwrap();
         let write_physical = write_physical_sym.into_raw();
 
-        let get_page_access_sym: Symbol<FnGetPageAccess> =
-            lib.get(b"kvmi_get_page_access\0").unwrap();
-        let get_page_access = get_page_access_sym.into_raw();
-
         let set_page_access_sym: Symbol<FnSetPageAccess> =
             lib.get(b"kvmi_set_page_access\0").unwrap();
         let set_page_access = set_page_access_sym.into_raw();
@@ -233,7 +225,6 @@ impl Libkvmi {
             get_vcpu_count,
             read_physical,
             write_physical,
-            get_page_access,
             set_page_access,
             get_registers,
             set_registers,


### PR DESCRIPTION
This PR drops libkvmi v6 compatibility in favor of libkvmi v7.

